### PR TITLE
Instead of fork and transfer to create derivative repos, use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ SOLAS is also an international maritime treaty to ensure ships comply with minim
 # Quickstart
 
 - Determine a [name](http://phrontistery.info/nautical.html) for your project, for example, `zabra`.
-- [Create](https://help.github.com/articles/creating-a-new-repository/) a new empty repo under the `samsung-cnct` [org](https://github.com/samsung-cnct) using your new name, for example https://github.com/samsung-cnct/zabra .
-- [Duplicate](https://help.github.com/articles/duplicating-a-repository/) this repo (https://github.com/samsung-cnct/solas) and push it to the `zabra` repo you created in the previous step (https://github.com/samsung-cnct/zabra). Note the arguments to clone and push.
+- [Create](https://help.github.com/articles/creating-a-new-repository/) a new empty repo under the `samsung-cnct` [org](https://github.com/samsung-cnct) named `zabra` using the GitHub GUI, for example https://github.com/samsung-cnct/zabra .
+- [Duplicate](https://help.github.com/articles/duplicating-a-repository/) this repo (https://github.com/samsung-cnct/solas) and push it to the `zabra` repo you created in the previous step. Note the arguments to clone and push.
 
 ```
 git clone --bare https://github.com/samsung-cnct/solas.git
 cd solas.git
 git push --mirror https://github.com/samsung-cnct/zabra.git
 cd ..
-rm -rf solas-chart.git
+rm -rf solas.git
 ```
 
-- [Fork](https://help.github.com/articles/fork-a-repo/) the `zabra` repo (https://github.com/samsung-cnct/zabra) from `samsung-cnct` and begin subimitting PRs.
+- [Fork](https://help.github.com/articles/fork-a-repo/) the `zabra` repo (https://github.com/samsung-cnct/zabra) from `samsung-cnct` and begin submiitting PRs.
 
 # Things to consider
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SOLAS is also an international maritime treaty to ensure ships comply with minim
 # Quickstart
 
 - Determine a [name](http://phrontistery.info/nautical.html) for your project, for example, `zabra`.
-- [Create](https://help.github.com/articles/creating-a-new-repository/) a new empty repo under the `samsung-cnct` [org](https://github.com/samsung-cnct) named `zabra` using the GitHub GUI, for example https://github.com/samsung-cnct/zabra .
+- [Create](https://help.github.com/articles/creating-a-new-repository/) a new empty repo under the `samsung-cnct` [org](https://github.com/samsung-cnct) using the GitHub GUI, for example https://github.com/samsung-cnct/zabra .
 - [Duplicate](https://help.github.com/articles/duplicating-a-repository/) this repo (https://github.com/samsung-cnct/solas) and push it to the `zabra` repo you created in the previous step. Note the arguments to clone and push.
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@ SOLAS is also an international maritime treaty to ensure ships comply with minim
 
 # Quickstart
 
-- Determine a [name](http://phrontistery.info/nautical.html) for your project
-- Fork [solas](https://github.com/samsung-cnct/solas)
-- [Rename](https://help.github.com/articles/renaming-a-repository/) it
-- [Transfer](https://help.github.com/articles/about-repository-transfers/) it to the samsung-cnct organization
-- Fork the new repo from samsung-cnct and begin subitting PRs
+- Determine a [name](http://phrontistery.info/nautical.html) for your project, for example, `zabra`.
+- [Create](https://help.github.com/articles/creating-a-new-repository/) a new empty repo under the `samsung-cnct` [org](https://github.com/samsung-cnct) using your new name, for example https://github.com/samsung-cnct/zabra .
+- [Duplicate](https://help.github.com/articles/duplicating-a-repository/) this repo (https://github.com/samsung-cnct/solas) and push it to the `zabra` repo you created in the previous step (https://github.com/samsung-cnct/zabra). Note the arguments to clone and push.
+
+```
+git clone --bare https://github.com/samsung-cnct/solas.git
+cd solas.git
+git push --mirror https://github.com/samsung-cnct/zabra.git
+cd ..
+rm -rf solas-chart.git
+```
+
+- [Fork](https://help.github.com/articles/fork-a-repo/) the `zabra` repo (https://github.com/samsung-cnct/zabra) from `samsung-cnct` and begin subimitting PRs.
 
 # Things to consider
 
 - You may want to update the teams [slack notifications](https://samsung-cnct.slack.com/apps/search?q=github) to notify developers of PR and issue activiy. To do this you will need [Admin Privileges](https://help.github.com/articles/repository-permission-levels-for-an-organization/). To ensure that you are not the only one who can maintain these integrations, it is recommended that you grant a GitHub Team (e.g. `commontools`) permissions and not a single individual contributor.
+
+- If your project will be administered by a GitHUb team (e.g. `commontools`), you will need to contact an owner of the `samsung-cnct` organization so they can grant the `commontools` team admin privileges. Reachout in the `#cnct-dev` or `#team-tooltime` Slack channels.
 
 - You will likely need to configure our [Jenkins CI](https://common-jenkins.kubeme.io/) to test, release and deploy changes.


### PR DESCRIPTION
bare clone and mirror to duplicate repos (fixes #6).